### PR TITLE
Coramin can be installed with pypi

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -28,13 +28,9 @@ Then install GALINI Python dependencies:
 
     pip install requirements.txt
 
-Install Coramin and its dependencies:
+Finally, install GALINI:
 
 ::
-
-    git clone git@github.com:Coramin/Coramin.git
-    cd Coramin
-    pip install pyomo scipy numpy
     python setup.py install
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 setuptools>=40.0.0
 numpy>=1.15.0
+coramin
 mkdocs
 mkdocstrings


### PR DESCRIPTION
This PR updates the documentation and requirements.txt to reflect that Coramin can be installed from PyPi.