### PR TITLE
robust use of find_component and better handling of bounds for quadratics

### DIFF
--- a/galini/branch_and_cut/node_storage.py
+++ b/galini/branch_and_cut/node_storage.py
@@ -96,11 +96,19 @@ class _NodeStorageBase:
             if isinstance(relaxation, PWXSquaredRelaxationData):
                 # w >= x^2: add an oa point in the midpoint
                 relaxation.clean_oa_points()
-                var_values = pe.ComponentMap()
                 x_var = relaxation.get_rhs_vars()[0]
-                midpoint = x_var.lb + 0.5*(x_var.ub - x_var.lb)
-                var_values[x_var] = midpoint
-                relaxation.add_oa_point(var_values)
+                if x_var.has_lb() and x_var.has_ub():
+                    midpoint = x_var.lb + 0.5*(x_var.ub - x_var.lb)
+                    relaxation.add_oa_point(pe.ComponentMap([(x_var, midpoint)]))
+                elif x_var.has_lb():
+                    if x_var.lb <= 0:
+                        relaxation.add_oa_point(pe.ComponentMap([(x_var, 1)]))
+                elif x_var.has_ub():
+                    if x_var.ub >= 0:
+                        relaxation.add_oa_point(pe.ComponentMap([(x_var, -1)]))
+                else:
+                    relaxation.add_oa_point(pe.ComponentMap([(x_var, -1)]))
+                    relaxation.add_oa_point(pe.ComponentMap([(x_var, 1)]))
 
             relaxation.rebuild()
 

--- a/galini/relaxations/relax.py
+++ b/galini/relaxations/relax.py
@@ -148,7 +148,7 @@ def relax(model, data, use_linear_relaxation=True):
     for var in model.component_data_objects(pe.Var,
                                             active=True,
                                             descend_into=True):
-        new_var = new_model.find_component(var.getname(fully_qualified=True))
+        new_var = new_model.find_component(var)
         data.original_to_new_var_map[var] = new_var
 
     model = new_model


### PR DESCRIPTION
- find component works better with components than with strings, especially when there are stings in indices
- special cases for quadratic expressions when the variable being squared does not have bounds